### PR TITLE
[BLOCKED by Gatsby]Remove unneeded analytics event tracking

### DIFF
--- a/packages/app-icon-explorer/src/components/IconsListing/components/SingleIcon.tsx
+++ b/packages/app-icon-explorer/src/components/IconsListing/components/SingleIcon.tsx
@@ -25,22 +25,11 @@ export default function SingleIcon({icon, isActive = false}: Props) {
     [styles.active]: isActive,
   });
 
-  const trackLink = () => {
-    if ((window as any).gtag) {
-      (window as any).gtag('event', 'select_icon', {
-        /* eslint-disable-next-line camelcase */
-        event_category: 'icons',
-        /* eslint-disable-next-line camelcase */
-        event_label: icon.reactname,
-      });
-    }
-  };
-
   const queryParams = useContext(QueryParamsContext);
   const linkTo = `/?${qsStringify({icon: icon.reactname, q: queryParams.q})}`;
 
   return (
-    <Link to={linkTo} className={className} onClick={trackLink}>
+    <Link to={linkTo} className={className}>
       <div className={styles.iconSvgWrapper}>
         <Icon source={encodeURIComponent(icon.svgContent)} />
       </div>

--- a/packages/app-icon-explorer/src/pages/index.tsx
+++ b/packages/app-icon-explorer/src/pages/index.tsx
@@ -169,15 +169,6 @@ export default class IndexPage extends React.Component<Props, State> {
   }
 
   private persistSearchText(dirtySearchText: string) {
-    if (dirtySearchText !== '' && (window as any).gtag) {
-      (window as any).gtag('event', 'search', {
-        /* eslint-disable-next-line camelcase */
-        event_category: 'icons',
-        /* eslint-disable-next-line camelcase */
-        search_term: dirtySearchText,
-      });
-    }
-
     const newQueryString = qsStringify({
       ...this.state.queryParams,
       ...{q: dirtySearchText === '' ? undefined : dirtySearchText},


### PR DESCRIPTION
EDIT Blocked till https://github.com/gatsbyjs/gatsby/issues/12484 is resolved

- Searches are now handled through the "Site Search" feature with the q
querystring parameter
- Opening up icon panels are already treated as distinct pages thanks to
the icon querystring parameter