### PR TITLE
Slightly cleaner setup for setting page titles

### DIFF
--- a/packages/app-icon-explorer/src/components/IconDetailsPanel/IconDetailsPanel.tsx
+++ b/packages/app-icon-explorer/src/components/IconDetailsPanel/IconDetailsPanel.tsx
@@ -264,7 +264,6 @@ function stringifyAliases(aliases: string[]) {
 function EmptyState() {
   return (
     <div className={styles.empty}>
-      <Seo title="Polaris icons" />
       <div>
         <TextStyle variation="subdued">Choose an icon to begin</TextStyle>
       </div>

--- a/packages/app-icon-explorer/src/components/Seo.tsx
+++ b/packages/app-icon-explorer/src/components/Seo.tsx
@@ -32,10 +32,6 @@ export default function Seo({
 }: Props) {
   const data = useStaticQuery(detailsQuery);
   const metaDescription = description || data.site.siteMetadata.description;
-  const titleTemplate =
-    title === data.site.siteMetadata.title
-      ? data.site.siteMetadata.title
-      : data.site.siteMetadata.titleTemplate;
 
   return (
     <Helmet
@@ -43,7 +39,8 @@ export default function Seo({
         lang,
       }}
       title={title}
-      titleTemplate={titleTemplate}
+      defaultTitle={data.site.siteMetadata.title}
+      titleTemplate={data.site.siteMetadata.titleTemplate}
       link={[
         {
           rel: 'icon',

--- a/packages/app-icon-explorer/src/pages/index.tsx
+++ b/packages/app-icon-explorer/src/pages/index.tsx
@@ -27,11 +27,6 @@ interface Props {
         node: IconInterface;
       }[];
     };
-    site: {
-      siteMetadata: {
-        title: string;
-      };
-    };
   };
 }
 
@@ -145,7 +140,7 @@ export default class IndexPage extends React.Component<Props, State> {
         onSearchBlur={this.handleSearchBlur}
         onSearchCancel={this.handleSearchCancel}
       >
-        <Seo title={this.props.data.site.siteMetadata.title} />
+        <Seo title="" />
         <div className={styles.page}>
           <div className={styles.listingWrapper}>
             <div className={styles.listing}>
@@ -268,11 +263,6 @@ function buildIconSets(icons: IconInterface[]) {
 
 export const pageQuery = graphql`
   query {
-    site {
-      siteMetadata {
-        title
-      }
-    }
     allPolarisYaml {
       edges {
         node {


### PR DESCRIPTION
If you set the Seo title to be empty then defaultTitle gets used, which
doesn't use the title template.