### PR TITLE
[WIP] Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feedback-for-polaris-icons-ui.md
+++ b/.github/ISSUE_TEMPLATE/feedback-for-polaris-icons-ui.md
@@ -1,9 +1,10 @@
 ---
 name: Feedback for Polaris icons UI
 about: For suggestions or issues related to https://polaris-icons.shopify.com
-title: '[Feedback]'
+title: "[Feedback]"
 labels: ''
 assignees: HYPD
+
 ---
 
 # Issue summary

--- a/.github/ISSUE_TEMPLATE/suggest-a-new-icon--shopify-employees-.md
+++ b/.github/ISSUE_TEMPLATE/suggest-a-new-icon--shopify-employees-.md
@@ -1,17 +1,17 @@
 ---
-name: Suggest changes to an existing icon
-about: For modifications of existing icons already in Polaris icons
-title: "[Suggestion]"
-labels: Update
+name: Suggest a new icon (Shopify employees)
+about: For adding new icons to Polaris icons
+title: "[Suggestion] Icon name"
+labels: New
 assignees: ''
 
 ---
 
 <!--
-Follow this template to change an existing icon.
+Follow this template to suggest a new icon.
 
-You should already understand the impact of this change,
-where the icon is used, etc.
+First check Abstract or https://polaris-icons.shopify.com
+to see if the icon you need already exists.
 
 Any questions?
 - https://vault.shopify.com/Polaris-icon-creation-guidelines
@@ -22,13 +22,9 @@ Any questions?
 
 @yourslackhandle
 
-### Original icon name
+### What team and project is this for?
 
-arrow down (minor)
-
-### When would you like it by?
-
-DD/MM/YYYY
+Team - Project
 
 ### How will this icon be used?
 
@@ -41,10 +37,10 @@ creating this icon, and any additional context.
 
 <!--
 Make sure you’ve created a branch with your new icon
-inside of Abstract (Polaris - Icons project) and link it here
+inside of Abstract (Polaris - Icons project) and link it here.
 -->
 
-### Updated icon SVG
+### Icon SVG
 
 <!--
 Link to the SVG file (you can host it in Google Drive)
@@ -55,13 +51,14 @@ or paste the SVG code below:
 <svg xmlns="http://www.w3.org/2000/svg" ...
 ```
 
-### Icon metadata (optional)
+### Icon metadata
 
 <!--
-If the icon metadata needs to be updated,
-copy and paste it from the appropriate `.yml` file, located in:
+If you’re adding a new icon, the following metadata needs
+to be completed before we can accept this contribution.
+
+You can find example metadata files in any `.yml` file here:
 https://github.com/Shopify/polaris-icons/tree/master/packages/polaris-icons-raw/icons/polaris
-then apply the changes below.
 -->
 
 ```yml

--- a/.github/ISSUE_TEMPLATE/suggest-a-new-icon.md
+++ b/.github/ISSUE_TEMPLATE/suggest-a-new-icon.md
@@ -1,9 +1,10 @@
 ---
 name: Suggest a new icon
 about: For adding new icons to Polaris icons
-title: '[Suggestion] Icon name'
+title: "[Suggestion] Icon name"
 labels: New
 assignees: ''
+
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/suggest-changes-to-an-existing-icon--shopify-employees-.md
+++ b/.github/ISSUE_TEMPLATE/suggest-changes-to-an-existing-icon--shopify-employees-.md
@@ -1,5 +1,5 @@
 ---
-name: Suggest changes to an existing icon
+name: Suggest changes to an existing icon (Shopify employees)
 about: For modifications of existing icons already in Polaris icons
 title: "[Suggestion]"
 labels: Update


### PR DESCRIPTION
As we aren't encouraging contribution from the public yet, we need to make it clear that suggesting new icons, and changes to existing icons is for Shopify employees only. It's not clear at the moment:

<img width="684" alt="Screen Shot 2019-06-27 at 11 18 57 AM" src="https://user-images.githubusercontent.com/970304/60518362-5fae9e80-9caf-11e9-84e9-9978e1366d87.png">

@alekmackie thoughts? For now I've added `(Shopify employees)` to the github issue templates titles.

cc @claydelk