### PR TITLE
Include polaris svg's in the Ruby gem

### DIFF
--- a/.shopify-build/polaris-icons-deploy-ruby.yml
+++ b/.shopify-build/polaris-icons-deploy-ruby.yml
@@ -12,6 +12,7 @@ shared:
     run:
       - sudo apt-get update
       - sudo apt-get install librsvg2-bin
+      - yarn install
       - cd packages-ruby/polaris_icons/
       - bundle install
       - bundle check

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ matrix:
         - '2.6.2'
       before_install:
         - sudo apt-get install -y librsvg2-bin
-      install: cd packages-ruby/polaris_icons && bundle install && bundle check
+      install: yarn install && cd packages-ruby/polaris_icons && bundle install && bundle check
       script:
         - ./scripts/build-gem.sh

--- a/packages-ruby/polaris_icons/polaris_icons.gemspec
+++ b/packages-ruby/polaris_icons/polaris_icons.gemspec
@@ -1,4 +1,4 @@
-version = "0.1.3"
+version = "0.1.4"
 
 Gem::Specification.new do |spec|
   spec.name          = "polaris_icons"

--- a/packages-ruby/polaris_icons/scripts/build-gem.sh
+++ b/packages-ruby/polaris_icons/scripts/build-gem.sh
@@ -1,10 +1,31 @@
 #!/usr/bin/env bash
 set -e
 
-mkdir -p ./images/pdf/
-for file in ../../packages/polaris-icons-raw/icons/polaris/*.svg; do
-  rsvg-convert -f pdf -o `echo $file | sed -e 's/.svg$/.pdf/' -e 's/..\/..\/packages\/polaris-icons-raw\/icons\/polaris\//images\/pdf\//'` "$file"
+function abs_path {
+  old_pwd=$(pwd)
+  cd "$1" && full_path=$(pwd)
+  cd "$old_pwd"
+  echo "$full_path"
+}
+
+
+function recursive_find_file {
+  path=$(abs_path "$1")
+  while [[ "$path" != "" && ! -e "$path/$2" ]]; do
+    path=${path%/*}
+  done
+  echo "$path"
+}
+
+script_dir=$(abs_path "$(dirname "${BASH_SOURCE[0]}")")
+gem_root=$(recursive_find_file "$script_dir" "polaris_icons.gemspec")
+proj_root=$(recursive_find_file "$script_dir" "dev.yml")
+
+mkdir -p "$gem_root/images/pdf/"
+
+for file in "$proj_root"/packages/polaris-icons-raw/icons/polaris/*.svg; do
+  rsvg-convert -f pdf -o $(echo "$file" | sed -e 's/.svg$/.pdf/' -e "s#$proj_root/packages/polaris-icons-raw/icons/polaris\/#$gem_root/images/pdf/#") "$file"
   echo "Converted $file"
 done
 
-bundle exec rake build
+cd $gem_root && bundle exec rake build

--- a/packages-ruby/polaris_icons/scripts/build-gem.sh
+++ b/packages-ruby/polaris_icons/scripts/build-gem.sh
@@ -22,10 +22,18 @@ gem_root=$(recursive_find_file "$script_dir" "polaris_icons.gemspec")
 proj_root=$(recursive_find_file "$script_dir" "dev.yml")
 
 mkdir -p "$gem_root/images/pdf/"
+mkdir -p "$gem_root/images/svg/"
+
+yarn workspace @shopify/polaris-icons --cwd "$proj_root" run build
 
 for file in "$proj_root"/packages/polaris-icons-raw/icons/polaris/*.svg; do
   rsvg-convert -f pdf -o $(echo "$file" | sed -e 's/.svg$/.pdf/' -e "s#$proj_root/packages/polaris-icons-raw/icons/polaris\/#$gem_root/images/pdf/#") "$file"
   echo "Converted $file"
+done
+
+for file in "$proj_root"/packages/polaris-icons/images/*.svg; do
+  cp "$file" "$gem_root/images/svg/"
+  echo "copied $file"
 done
 
 cd $gem_root && bundle exec rake build


### PR DESCRIPTION
This PR provides a way of packaging the most recent SVG files from `polaris-icons` into the Ruby package, so they can be used from applications without relying on the javascript libraries.

