### PR TITLE
Generate the .xcassets for Xcode projects

### DIFF
--- a/packages-ruby/polaris_icons/Gemfile.lock
+++ b/packages-ruby/polaris_icons/Gemfile.lock
@@ -6,12 +6,12 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    byebug (11.0.1)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     highline (1.6.20)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
+    json (2.2.0)
     json_pure (1.8.1)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
@@ -40,7 +40,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.17)
-  byebug (~> 11.0)
+  json (~> 2.2)
   package_cloud
   polaris_icons!
   rake (~> 10.0)

--- a/packages-ruby/polaris_icons/Rakefile
+++ b/packages-ruby/polaris_icons/Rakefile
@@ -1,5 +1,8 @@
+$LOAD_PATH.unshift(File.join(__dir__, "lib"))
+
 require 'fileutils'
 require "bundler/gem_tasks"
+require 'polaris_icons'
 
 task :default => :spec
 
@@ -14,11 +17,15 @@ def convert_and_copy_gem_icons
   # Paths
   svg_path = File.join(__dir__, "images/svg")
   pdf_path = File.join(__dir__, "images/pdf")
+  asset_catalogs_path = File.join(__dir__, "images/asset_catalogs")
 
   FileUtils.mkdir_p(svg_path)
   FileUtils.mkdir_p(pdf_path)
+  FileUtils.rm_r(asset_catalogs_path, force: true)
+  FileUtils.mkdir_p(asset_catalogs_path)
 
   # Copy
+  asset_catalog = PolarisIcons::AssetCatalog.new
   Dir.glob(File.join(root_path, "packages/polaris-icons/images/*.svg")).each do |path|
     # SVG
     output_svg_path = File.join(svg_path, File.basename(path))
@@ -27,6 +34,7 @@ def convert_and_copy_gem_icons
 
     # PDF
     output_pdf_path = File.join(pdf_path, File.basename(path).gsub(".svg", ".pdf"))
+    asset_catalog.add_pdf(output_pdf_path)
     system(
       "rsvg-convert",
       "-f", "pdf",
@@ -35,6 +43,7 @@ def convert_and_copy_gem_icons
     ) || abort
     puts "Copied to #{output_pdf_path}"
   end
+  asset_catalog.write(asset_catalogs_path)
 end
 
 

--- a/packages-ruby/polaris_icons/lib/polaris_icons.rb
+++ b/packages-ruby/polaris_icons/lib/polaris_icons.rb
@@ -1,0 +1,3 @@
+module PolarisIcons
+  autoload :AssetCatalog, 'polaris_icons/asset_catalog'
+end

--- a/packages-ruby/polaris_icons/lib/polaris_icons/asset_catalog.rb
+++ b/packages-ruby/polaris_icons/lib/polaris_icons/asset_catalog.rb
@@ -58,17 +58,3 @@ module PolarisIcons
 
   end
 end
-
-
-# {
-#   "images" : [
-#     {
-#       "idiom" : "universal",
-#       "filename" : "activities_major_monotone.pdf"
-#     }
-#   ],
-#   "info" : {
-#     "version" : 1,
-#     "author" : "xcode"
-#   }
-# }

--- a/packages-ruby/polaris_icons/lib/polaris_icons/asset_catalog.rb
+++ b/packages-ruby/polaris_icons/lib/polaris_icons/asset_catalog.rb
@@ -1,0 +1,74 @@
+require 'fileutils'
+require 'json'
+
+module PolarisIcons
+  class AssetCatalog
+
+    def initialize(name: "PolarisIcons", author: "Polaris")
+      @name = name
+      @author = author
+      @pdfs = []
+    end
+
+    def add_pdf(path)
+      @pdfs << path
+    end
+
+    def write(path)
+      xcassets_path = File.join(path, "#{@name}.xcassets")
+      FileUtils.mkdir_p(xcassets_path)
+
+      write_contents_json(xcassets_path)
+      write_image_sets(xcassets_path)
+    end
+
+    private
+
+    def write_image_sets(xcassets_path)
+      @pdfs.each do |pdf_path|
+        file_name = File.basename(pdf_path)
+        name = file_name.gsub(".pdf", "")
+
+        imageset_path = File.join(xcassets_path, "#{name}.imageset")
+        FileUtils.mkdir_p(imageset_path)
+
+        # Copy the image
+        FileUtils.cp(pdf_path, File.join(imageset_path, file_name))
+
+        contents = { images: [{ idiom: "universal", filename: file_name }]}
+        contents.merge!(info)
+        json = JSON.pretty_generate(contents)
+        File.write(File.join(imageset_path, "Contents.json"), json)
+      end
+    end
+
+    def write_contents_json(xcassets_path)
+      json = JSON.pretty_generate(info)
+      File.write(File.join(xcassets_path, "Contents.json"), json)
+    end
+
+    def info
+      {
+        info: {
+          version: 1,
+          author: @author
+        }
+      }
+    end
+
+  end
+end
+
+
+# {
+#   "images" : [
+#     {
+#       "idiom" : "universal",
+#       "filename" : "activities_major_monotone.pdf"
+#     }
+#   ],
+#   "info" : {
+#     "version" : 1,
+#     "author" : "xcode"
+#   }
+# }

--- a/packages-ruby/polaris_icons/polaris_icons.gemspec
+++ b/packages-ruby/polaris_icons/polaris_icons.gemspec
@@ -36,4 +36,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "package_cloud"
+  spec.add_development_dependency "json", "~> 2.2"
 end


### PR DESCRIPTION
Extend the task that generates the images to generate an asset catalog for Polaris Icons that we can add to any Xcode project.

[This PR](https://github.com/Shopify/polaris-icons/pull/660) should be merged first.