### PR TITLE
Fix the pipeline that deploys the Ruby gem

### DIFF
--- a/.shopify-build/polaris-icons-deploy-ruby.yml
+++ b/.shopify-build/polaris-icons-deploy-ruby.yml
@@ -1,4 +1,6 @@
 containers:
+  packagecloud:
+    docker: gcr.io/shopify-docker-images/ci/packagecloud:0.1
   ruby:
     docker: circleci/ruby:2.5.1-node
   macos:
@@ -16,13 +18,11 @@ steps:
   - wait
 
   - label: Build Gem
-    container: ruby
-    timeout: 5m
+    container: macos
+    timeout: 10m
     run:
-      - sudo apt-get update
-      - sudo apt-get install librsvg2-bin
-      - 'sudo chown -R circleci:circleci node_modules packages/*/bin || true'
       - yarn install
+      - brew install librsvg
       - cd packages-ruby/polaris_icons/
       - bundle install
       - bundle check
@@ -36,10 +36,11 @@ steps:
   - wait
 
   - label: Publish Gem to Packagecloud
-    timeout: 5m
-    container: macos
+    timeout: 10m
+    container: packagecloud
     run:
       - cd packages-ruby/polaris_icons/
+      - apt-get update && apt upgrade -y && apt install build-essential -y
       - bundle install
       - CURRENT_VERSION=`ls -l pkg | grep '.gem' | sed -e 's/.*polaris_icons-//' -e 's/.gem//'`
       - ./../../scripts/should_release_gem.rb "$CURRENT_VERSION"

--- a/packages-ruby/polaris_icons/Gemfile.lock
+++ b/packages-ruby/polaris_icons/Gemfile.lock
@@ -8,7 +8,6 @@ GEM
   specs:
     ansi (1.5.0)
     builder (3.2.3)
-    byebug (11.0.1)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     highline (1.6.20)
@@ -53,7 +52,6 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.17)
-  byebug (~> 11.0)
   json (~> 2.2)
   minitest (~> 5.11)
   minitest-reporters

--- a/packages-ruby/polaris_icons/polaris_icons.gemspec
+++ b/packages-ruby/polaris_icons/polaris_icons.gemspec
@@ -36,5 +36,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "json", "~> 2.2"
-  spec.add_development_dependency "byebug", "~> 11.0"
 end

--- a/packages-ruby/polaris_icons/test/test_helper.rb
+++ b/packages-ruby/polaris_icons/test/test_helper.rb
@@ -4,7 +4,6 @@ require "polaris_icons"
 
 require "minitest/autorun"
 require "mocha/minitest"
-require "byebug"
 require "minitest/reporters"
 
 require 'test_helper/fixtures'


### PR DESCRIPTION
After introducing the logic that generates the Swift interface for consuming the icons from Xcode projects, the deploy pipeline started failing.
This PR fixes this issue by configuring the deploy step to run in a macOS container that has the `swiftgen` tool necessary to generate the interface.

[**Example build**](https://buildkite.com/shopify/polaris-icons-deploy-ruby/builds/43#f06f526c-a664-4885-8fdc-09a82639b9ee)