### PR TITLE
Enabling Shopify Build Pipeline: polaris-icons-android

### DIFF
--- a/.shopify-build/polaris-icons-android.yml
+++ b/.shopify-build/polaris-icons-android.yml
@@ -1,0 +1,10 @@
+containers:
+  default:
+    docker: circleci/ruby:2.5.1-node-browsers
+
+steps:
+- label: Tests
+  timeout: 5m
+  run:
+  - echo "Hello World"
+


### PR DESCRIPTION
## Enabling the Shopify Build Pipeline: polaris-icons-android

This PR adds Shopify Build to this repository.

**Please review this PR before merging it!**

- [ ] Head over to the Shopify Build [documentation](https://apidocs.shopify.io/shopify-build/) to learn more about configurating it.
- [ ] Examine your `shipit.yml` configuration file as it may be configured to depend on the [CircleCI status](https://github.com/Shopify/shipit-engine#ci). You can reference a pipeline in the `shipit.yml` file by using `buildkite/polaris-icons-android` as seen [here](https://github.com/Shopify/shopify-build/blob/f263a410151e4e56ee610801cfbc285e0b69f25d/shipit.yml#L19).
- [ ] Don't forget to replace your old CI badge with the Shopify Build one. You can get it [here](https://buildkite.com/shopify/polaris-icons-android/settings/badges).
- [ ] If you are using codecov.io for code coverage, you'll need to add the `CODECOV_TOKEN` environment variable to your Shopify Build pipeline. The token can be found at [codecov](https://codecov.io/gh/Shopify/polaris-icons/settings) and should be placed in the environment section of the `.shopify-build/secrets.ejson` file. [More info](https://apidocs.shopify.io/shopify-build/jobs/defining_jobs/#secrets-as-environment-variables).
- [ ] Rebase and squash the commits into one and don't forget to remove the `[ci skip]` part from the commit message:
      `git rebase -i 133b502e6b8a672141d055ab34de01955f4b52d0`
- [ ] We disabled commit statuses on new PRs for your pipeline to prevent other branches from being blocked while you are setting up Shopify Build. [See the builds for your polaris-icons-android pipeline](https://buildkite.com/shopify/polaris-icons-android/builds?branch=shopify-build-add-polaris-icons-android).

## Cleanup After Merging

- [ ] Enable commit statuses for the PRs in your repository by running (You will have to rerun your builds to start seeing them):
      `spy build status yes polaris-icons-android`.
- [ ] After merging the changes to set up Shopify Build you can remove CircleCI from your project by running `spy circle remove Shopify/polaris-icons`.
- [ ] Let people know with branches that are behind the `master` branch that their PRs are failing, because they are missing the necessary configuration files. You can use the following reply: “We migrated this repository from CircleCI to Shopify Build. Your build is failing, because your branch doesn't include the necessary configuration files. The configuration files are missing because your branch is behind the `master` branch. You should rebase your branch to make the build pass with `git pull --rebase origin master`”

## Questions about this PR?
Join the `#shopify-build` Slack channel.

Annoyed by how much you have to do yourself? Make it better in [spy](https://github.com/Shopify/spy/blob/master/app/shopify_build.rb).
