### PR TITLE
[do not merge] Show twotone icons in the grid, with a dark accent

### DIFF
--- a/packages/app-icon-explorer/src/components/IconsListing/components/SingleIcon.module.scss
+++ b/packages/app-icon-explorer/src/components/IconsListing/components/SingleIcon.module.scss
@@ -26,4 +26,8 @@
 .iconSvgWrapper {
   padding-top: 24px;
   padding-bottom: 16px;
+
+  svg {
+    width: 20px;
+  }
 }

--- a/packages/app-icon-explorer/src/components/IconsListing/components/SingleIcon.tsx
+++ b/packages/app-icon-explorer/src/components/IconsListing/components/SingleIcon.tsx
@@ -1,7 +1,7 @@
 import React, {useContext, useCallback} from 'react';
 import classNames from 'classnames';
 import {stringify as qsStringify} from 'query-string';
-import {Caption, UnstyledLink} from '@shopify/polaris';
+import {Caption, UnstyledLink, Icon} from '@shopify/polaris';
 import {QueryParamsContext} from '../../AppFrame';
 import {Icon as IconInterface} from '../../../types';
 import styles from './SingleIcon.module.scss';
@@ -33,16 +33,15 @@ export default function SingleIcon({icon, isActive = false}: Props) {
 
   return (
     <UnstyledLink url={linkTo} className={className} onClick={trackLink}>
-      <div className={styles.iconSvgWrapper}>
-        <img
-          width="20"
-          height="20"
-          src={`data:image/svg+xml;utf8,${encodeURIComponent(
-            icon.styles.monotone.svgContent,
-          )}`}
-          alt=""
-        />
-      </div>
+      <div
+        className={styles.iconSvgWrapper}
+        dangerouslySetInnerHTML={{
+          __html: icon.styles.twotone
+            ? icon.styles.twotone.svgContent.replace('#FFF', '#637381')
+            : icon.styles.monotone.svgContent,
+        }}
+      />
+
       <div className={styles.iconLabel}>
         <Caption>{icon.name}</Caption>
       </div>


### PR DESCRIPTION
This pull request is for demonstrative purposes, in order to see what twotone icons look like with a dark accent, in case any of them would be suitable as-is if the icon system switched to a "plain icons" style.