### PR TITLE
Enable Dependabot on your Project

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,5 @@
+version: 1
+update_configs:
+- package_manager: "ruby:bundler"
+  directory: "/"
+  update_schedule: "weekly"


### PR DESCRIPTION
**Owners**: @Shopify/polaris
**Service**: [polaris-icons](https://services.shopify.io/services/polaris-icons)
**App**: polaris-icons-production

### :robot: Enable [Dependabot](https://dependabot.com/) on your Project :robot:

#### What is Dependabot?
Dependabot is a third-party tool provided by GitHub who aims to make your life easier by
automating dependencies upgrade.
It tremendously helped us keep our dependencies up to date in Core and we want every Ruby project at Shopify
to enable it.

#### What does this PR do?
This PR creates the minimal configuration required by Dependabot to opt-in your project.
This configuration file tells Dependabot to bump your dependencies on a weekly basis.

#### What do I need to do?
Dependabot is supposed to do the work for you and there isn't much you'll have to take care of.
By default the :robot: will bump the dependencies you declared in your Gemfile and open a Pull Request.
You'll have to review the handy diff provided in the PR description and merge it.

#### I don't like the default configuration
You are free to modify the default configuration the way you want.
You might for example prefer having "live" bumps or add a reviewer on PR created by the :robot:.
You can tweak the configuration file by following the Dependabot [doc](https://dependabot.com/docs/config-file/).

:warning: You are free to modify any configuration, including the `update_schedule` one.
However bumping dependencies **has** to be done at the minimum on a weekly basis
(ie. you can't change the `update_schedule: "monthly"`).
