### PR TITLE
Bump package versions

### DIFF
--- a/packages-ruby/polaris_icons/package.json
+++ b/packages-ruby/polaris_icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polaris_icons",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "SEE LICENSE IN LICENSE.md",
   "author": "Shopify Inc.",
   "main": "polaris_icons.gemspec",

--- a/packages/app-icon-explorer/package.json
+++ b/packages/app-icon-explorer/package.json
@@ -1,11 +1,11 @@
 {
   "name": "app-icon-explorer",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "private": true,
   "dependencies": {
     "@shopify/polaris": "^3.17.0",
-    "@shopify/polaris-icons": "^3.6.0",
-    "@shopify/polaris-icons-raw": "^1.8.0",
+    "@shopify/polaris-icons": "^3.7.0",
+    "@shopify/polaris-icons-raw": "^1.9.0",
     "@shopify/polaris-tokens": "^2.6.0",
     "@shopify/react-shortcuts": "^2.2.1",
     "@types/classnames": "^2.2.7",

--- a/packages/polaris-icons-audit/package.json
+++ b/packages/polaris-icons-audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/polaris-icons-audit",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "license": "SEE LICENSE IN LICENSE.md",
   "author": "Shopify Inc.",
   "main": "index.js",
@@ -35,6 +35,6 @@
     "yargs": "^13.2.1"
   },
   "devDependencies": {
-    "@shopify/polaris-icons": "^3.6.0"
+    "@shopify/polaris-icons": "^3.7.0"
   }
 }

--- a/packages/polaris-icons-internal/package.json
+++ b/packages/polaris-icons-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/polaris-icons-internal",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "license": "SEE LICENSE IN LICENSE.md",
   "author": "Shopify Inc.",
   "main": "index.js",
@@ -31,7 +31,7 @@
   },
   "homepage": "https://polaris-icons.shopify.com",
   "devDependencies": {
-    "@shopify/polaris-icons-raw": "^1.8.0",
+    "@shopify/polaris-icons-raw": "^1.9.0",
     "rollup": "^1.3.2"
   }
 }

--- a/packages/polaris-icons-raw/package.json
+++ b/packages/polaris-icons-raw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/polaris-icons-raw",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Raw SVG files for all icons in the Shopify Polaris design system",
   "author": "Shopify Inc.",
   "homepage": "https://github.com/shopify/polaris-icons/tree/master/packages/polaris-icons-raw#readme",

--- a/packages/polaris-icons/CHANGELOG.md
+++ b/packages/polaris-icons/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
-<!-- ## Unreleased -->
+## 3.7.0 - 2019-09-27
+
+### Added
+
+- iOS asset catalog.
+- Android drawables.
 
 ## 3.6.0 - 2019-09-16
 

--- a/packages/polaris-icons/package.json
+++ b/packages/polaris-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/polaris-icons",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "license": "SEE LICENSE IN LICENSE.md",
   "author": "Shopify Inc.",
   "main": "index.js",
@@ -32,7 +32,7 @@
   },
   "homepage": "https://polaris-icons.shopify.com/",
   "devDependencies": {
-    "@shopify/polaris-icons-raw": "^1.8.0",
+    "@shopify/polaris-icons-raw": "^1.9.0",
     "rollup": "^1.3.2"
   }
 }


### PR DESCRIPTION
Bump the version of Polaris Icons to include the Android drawables and iOS asset catalog.