### PR TITLE
Generate the Android drawables using svg2vd

### DIFF
--- a/.shopify-build/polaris-icons-deploy-ruby.yml
+++ b/.shopify-build/polaris-icons-deploy-ruby.yml
@@ -1,6 +1,6 @@
 containers:
   packagecloud:
-    docker: gcr.io/shopify-docker-images/ci/packagecloud:0.1
+    docker: gcr.io/shopify-docker-images/ci/packagecloud:0.2
   ruby:
     docker: circleci/ruby:2.6.4-node
   macos:

--- a/packages-ruby/polaris_icons/Gemfile.lock
+++ b/packages-ruby/polaris_icons/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    polaris_icons (0.3.0)
+    polaris_icons (0.4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/packages-ruby/polaris_icons/lib/polaris_icons/drawables_generator.rb
+++ b/packages-ruby/polaris_icons/lib/polaris_icons/drawables_generator.rb
@@ -1,12 +1,23 @@
 require 'open3'
 require 'tmpdir'
 require 'yaml'
+require "fileutils"
 
 module PolarisIcons
   class DrawablesGenerator
     def generate(svgs_path, drawables_path)
       root_path = File.expand_path("../../../../", __dir__)
-      PolarisIcons.execute("yarn", "--cwd", root_path, "run", "svg2vectordrawable", "-f", svgs_path, "-o", drawables_path)
+      jar_path = File.join(root_path, "bin", "svg2vd-0.1.jar")
+
+      Dir.glob(File.join(svgs_path, "*.svg")) do |svg_path|
+        # Android doesn't support the "-" character in the name, which some icons have.
+        path_with_valid_name = File.join(File.dirname(svg_path), File.basename(svg_path).gsub("-", "_"))
+        unless path_with_valid_name == svg_path
+          FileUtils.move(svg_path, path_with_valid_name, force: true)
+        end
+
+        PolarisIcons.execute("java", "-jar", jar_path, path_with_valid_name, drawables_path)
+      end
     end
   end
 end

--- a/packages-ruby/polaris_icons/package.json
+++ b/packages-ruby/polaris_icons/package.json
@@ -13,9 +13,7 @@
     "url": "git+https://github.com/Shopify/polaris-icons.git",
     "directory": "packages-ruby/polaris_icons"
   },
-  "devDependencies": {
-    "svg2vectordrawable": "^2.6.16"
-  },
+  "devDependencies": {},
   "bugs": {
     "url": "https://github.com/Shopify/polaris-icons/issues"
   },

--- a/packages-ruby/polaris_icons/test/polaris_icons/drawables_generator_test.rb
+++ b/packages-ruby/polaris_icons/test/polaris_icons/drawables_generator_test.rb
@@ -15,16 +15,20 @@ module PolarisIcons
     def test_generate
       # Given
       svgs_path = File.join(@tmp_dir, "svgs")
+      FileUtils.mkdir_p(svgs_path)
+      svg_path = File.join(svgs_path, "polaris-icon.svg")
+      FileUtils.touch(svg_path)
       drawables_path = File.join(@tmp_dir, "drawables")
       root_path = File.expand_path("../../../..", __dir__)
 
       PolarisIcons
         .expects(:execute)
-        .with("yarn",
-          "--cwd", root_path,
-          "run", "svg2vectordrawable",
-          "-f", svgs_path,
-          "-o", drawables_path
+        .with(
+          "java",
+          "-jar",
+          File.join(root_path, "bin/svg2vd-0.1.jar"),
+          File.join(svgs_path, "polaris_icon.svg"),
+          drawables_path
         )
 
       # Then


### PR DESCRIPTION
As @jaredh pointed out, using `svg2vd` is a better idea since it uses the tooling from the Android SDK to make the conversion.

This PR updates the implementation to use `svg2vd` instead.

### How to tophat