### PR TITLE
Specify Node engine in root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "packages-ruby/*"
   ],
   "engines": {
-    "node": "10.13.0"
+    "node": "10.x"
   },
   "devDependencies": {
     "@babel/core": "^7.4.3",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     "packages/*",
     "packages-ruby/*"
   ],
+  "engines": {
+    "node": "10.13.0"
+  },
   "devDependencies": {
     "@babel/core": "^7.4.3",
     "@shopify/images": "^1.1.5",


### PR DESCRIPTION
Fixes an issue where Heroku deploys would run Node v12 and this builds would break.